### PR TITLE
implement the new client interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,50 @@ Methods are called when a DBus client calls that method on the server. Propertie
 
 To emit a signal, just call the method marked with the `signal` decorator and the signal will be emitted with the returned value.
 
+## The Client Interface
+
+You can get a proxy object for a name on the bus with the `bus.getProxyObject()` function, passing the name and the path. The proxy object contains introspection data about the object including a list of nodes and interfaces. You can get an interface with the `object.getInterface()` function passing the name of the interface.
+
+The interface object has methods you can call that correspond to the methods in the introspection data. Pass normal JavaScript objects to the parameters of the function and they will automatically be converted into the advertized DBus type. However, you must use the `Variant` class to represent DBus variants.
+
+Methods will similarly return JavaScript objects converted from the advertised DBus type, with the `Variant` class used to represent returned variants. If the method returns multiple values, they will be returned within an array.
+
+The interface object is an event emitter that will emit the name of a signal when it is emitted on the bus. Arguments to the callback should correspond to the arguments of the signal.
+
+This is a brief example of using a proxy object with the [MPRIS](https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html) media player interface.
+
+```js
+let dbus = require('dbus-next');
+let bus = dbus.sessionBus();
+let Variant = dbus.Variant;
+
+// getting an object introspects it on the bus and creates the interfaces
+let obj = await bus.getProxyObject('org.mpris.MediaPlayer2.vlc', '/org/mpris/MediaPlayer2');
+
+// the interfaces are the primary way of interacting with objects on the bus
+let player = obj.getInterface('org.mpris.MediaPlayer2.Player');
+let properties = obj.getInterface('org.freedesktop.DBus.Properties');
+
+// call methods on the interface
+await player.Play()
+
+// get properties with the properties interface (this returns a variant)
+let volumeVariant = await properties.Get('org.mpris.MediaPlayer2.Player', 'Volume');
+console.log('current volume: ' + volumeVariant.value);
+
+// set properties with the properties interface using a variant
+await properties.Set('org.mpris.MediaPlayer2.Player', 'Volume', new Variant('d', volumeVariant.value + 0.05));
+
+// listen to signals
+properties.on('PropertiesChanged', (iface, changed, invalidated) => {
+  for (let prop of Object.keys(changed)) {
+    console.log(`property changed: ${prop}`);
+  }
+});
+```
+
+For a complete example, see the [MPRIS client](https://github.com/acrisci/node-dbus-next/blob/master/examples/mpris.js) example which can be used to control media players on the command line.
+
 ## Contributing
 
 Contributions are welcome. There's alot to do! Look at the issue tracker for [dbus-native](https://github.com/sidorares/dbus-native) for all those tricky bugs that require breaking the interface. I'll be pulling in a lot of outstanding pull requests from the project as well.

--- a/examples/mpris.js
+++ b/examples/mpris.js
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+let dbus = require('../');
+let program = require('commander');
+
+const MPRIS_IFACE = 'org.mpris.MediaPlayer2.Player';
+const MPRIS_PATH = '/org/mpris/MediaPlayer2';
+const PROPERTIES_IFACE = 'org.freedesktop.DBus.Properties';
+
+async function listAll() {
+  let result = [];
+  let bus = dbus.sessionBus();
+  let obj = await bus.getProxyObject('org.freedesktop.DBus', '/org/freedesktop/DBus');
+  let iface = obj.getInterface('org.freedesktop.DBus');
+  let names = await iface.ListNames();
+  for (let n of names) {
+    if (n.startsWith('org.mpris.MediaPlayer2.')) {
+      result.push(n);
+    }
+  }
+  return result;
+}
+
+function printEpilogue() {
+  console.log('');
+  console.log('Commands:');
+  console.log('  play, pause, stop, metadata, now-playing');
+}
+
+program
+  .version('0.0.1')
+  .arguments('<command>')
+  .option('-p, --player <player>', 'The player to control')
+  .option('-l, --list-all', 'List all players and exit');
+
+program.on('--help', printEpilogue);
+program.parse(process.argv)
+
+if (!program.listAll && !program.args.length) {
+  program.outputHelp();
+  printEpilogue();
+  process.exit(0);
+}
+
+async function printNames() {
+  let names = await listAll();
+  for (let n of names) {
+    console.log(n);
+  }
+}
+
+function printMetadata(metadata) {
+  for (k of Object.keys(metadata.value)) {
+    let value = metadata.value[k].value;
+    console.log(k.padEnd(23) + value);
+  }
+}
+
+let lastNowPlaying = '';
+
+function printNowPlaying(metadata) {
+  let artistVariant = metadata.value['xesam:artist'];
+  let titleVariant = metadata.value['xesam:title'];
+  let artist = artistVariant ? artistVariant.value : 'unknown';
+  let title = titleVariant ? titleVariant.value : 'unknown';
+  let nowPlaying = `${artist} - ${title}`;
+
+  if (lastNowPlaying !== nowPlaying) {
+    console.log(nowPlaying);
+    lastNowPlaying = nowPlaying;
+  }
+}
+
+async function nowPlaying(obj) {
+  return new Promise(resolve => {
+    let props = obj.getInterface(PROPERTIES_IFACE);
+    props.on('PropertiesChanged', (iface, changed, invalidated) => {
+      if (changed.hasOwnProperty('Metadata')) {
+        printNowPlaying(changed['Metadata']);
+      }
+    });
+  });
+}
+
+async function main() {
+  if (program.listAll) {
+    await printNames();
+    return 0;
+  }
+
+  let command = program.args[0];
+  if (['play', 'pause', 'stop', 'metadata', 'now-playing'].indexOf(command) === -1) {
+    program.outputHelp();
+    printEpilogue();
+    return 1;
+  }
+
+  let playerName = program.player;
+  if (!playerName) {
+    let names = await listAll();
+    if (!names.length) {
+      console.error('no players found');
+      return 1;
+    }
+    playerName = names[0];
+  }
+  if (!playerName.startsWith('org.mpris.MediaPlayer2')) {
+    playerName = `org.mpris.MediaPlayer2.${program.player}`;
+  }
+
+  let bus = dbus.sessionBus();
+  let obj = await bus.getProxyObject(playerName, MPRIS_PATH);
+  let player = obj.getInterface(MPRIS_IFACE);
+  let props = obj.getInterface(PROPERTIES_IFACE);
+
+  switch (command) {
+    case 'play':
+      await player.Play();
+      break;
+    case 'pause':
+      await player.Pause();
+      break;
+    case 'stop':
+      await player.Stop();
+      break;
+    case 'metadata': {
+      let metadata = await props.Get(MPRIS_IFACE, 'Metadata');
+      printMetadata(metadata);
+      break;
+    }
+    case 'now-playing': {
+      let metadata = await props.Get(MPRIS_IFACE, 'Metadata');
+      printNowPlaying(metadata);
+      await nowPlaying(obj);
+      // doesnt return
+      break;
+    }
+  }
+
+  return 0;
+}
+
+main()
+  .then(status => {
+    process.exit(status || 0);
+  })
+  .catch(error => {
+    console.log(error);
+    process.exit(1);
+  });

--- a/lib/bus.js
+++ b/lib/bus.js
@@ -3,11 +3,14 @@ const constants = require('./constants');
 const stdDbusIfaces = require('./stdifaces');
 const handleMethod = require('./service/handlers');
 const introspect = require('./introspect').introspectBus;
+
+// new
 const Name = require('./service/name');
 let {
   assertInterfaceNameValid,
   assertObjectPathValid
 } = require('./validators');
+let ProxyObject = require('./client/proxy-object');
 
 module.exports = function bus(conn, opts) {
   if (!(this instanceof bus)) {
@@ -203,6 +206,7 @@ module.exports = function bus(conn, opts) {
   this.nameRequests = {};
   this.names = {};
 
+  // new
   this.export = function(name, path, iface) {
     assertInterfaceNameValid(name);
     assertObjectPathValid(path);
@@ -235,6 +239,12 @@ module.exports = function bus(conn, opts) {
     });
 
     return this.nameRequests[name];
+  }
+
+  // new
+  this.getProxyObject = async function(name, path) {
+    let obj = new ProxyObject(this, name, path);
+    return obj._init();
   }
 
   this.exportInterface = function(obj, path, iface) {

--- a/lib/client/proxy-interface.js
+++ b/lib/client/proxy-interface.js
@@ -1,0 +1,101 @@
+let EventEmitter = require('events');
+const {
+  isInterfaceNameValid,
+  isMemberNameValid
+} = require('../validators');
+
+class ProxyInterface extends EventEmitter {
+  constructor(name, object) {
+    super();
+    this.$name = name;
+    this.$object = object;
+    this.$properties = [];
+    this.$methods = [];
+    this.$signals = [];
+  }
+
+  static _fromXml(object, xml) {
+    if (!xml.hasOwnProperty('$') || !isInterfaceNameValid(xml['$'].name)) {
+      return null;
+    }
+
+    let name = xml['$'].name;
+    let iface = new ProxyInterface(name, object)
+
+    if (Array.isArray(xml.property)) {
+      for (let p of xml.property) {
+        // TODO validation
+        if (p.hasOwnProperty('$')) {
+          iface.$properties.push(p['$']);
+        }
+      }
+    }
+
+    if (Array.isArray(xml.signal)) {
+      for (let s of xml.signal) {
+        if (!s.hasOwnProperty('$') || !isMemberNameValid(s['$'].name)) {
+          continue;
+        }
+        let signal = {
+          name: s['$'].name,
+          signature: ''
+        };
+
+        if (Array.isArray(s.arg)) {
+          for (let a of s.arg) {
+            if (a.hasOwnProperty('$') && a['$'].hasOwnProperty('type')) {
+              // TODO signature validation
+              signal.signature += a['$'].type;
+            }
+          }
+        }
+
+        iface.$signals.push(signal);
+      }
+    }
+
+    if (Array.isArray(xml.method)) {
+      for (let m of xml.method) {
+        if (!m.hasOwnProperty('$') || !isMemberNameValid(m['$'].name)) {
+          continue;
+        }
+        let method = {
+          name: m['$'].name,
+          inSignature: '',
+          outSignature: ''
+        };
+
+        if (Array.isArray(m.arg)) {
+          for (let a of m.arg) {
+            if (!a.hasOwnProperty('$') || typeof a['$'].type !== 'string') {
+              continue;
+            }
+            let arg = a['$'];
+            if (arg.direction === 'in') {
+              method.inSignature += arg.type;
+            } else if (arg.direction === 'out') {
+              method.outSignature += arg.type;
+            }
+          }
+        }
+
+        // TODO signature validation
+        iface.$methods.push(method);
+
+        iface[method.name] = async function(...args) {
+          let objArgs = [
+            name,
+            method.name,
+            method.inSignature,
+            method.outSignature
+          ].concat(args);
+          return object.callMethod.apply(object, objArgs);
+        }
+      }
+    }
+
+    return iface;
+  }
+}
+
+module.exports = ProxyInterface;

--- a/lib/client/proxy-object.js
+++ b/lib/client/proxy-object.js
@@ -1,0 +1,159 @@
+const xml2js = require('xml2js');
+const parseSignature = require('../signature');
+const ProxyInterface = require('./proxy-interface');
+const variant = require('../service/variant');
+const Variant = variant.Variant;
+const {
+  assertInterfaceNameValid,
+  assertObjectPathValid,
+  isObjectPathValid,
+  isInterfaceNameValid
+} = require('../validators');
+
+class ProxyObject {
+  constructor(bus, name, path) {
+    assertInterfaceNameValid(name);
+    assertObjectPathValid(path);
+    this.bus = bus;
+    this.name = name;
+    this.path = path;
+    this.nodes = [];
+    this.interfaces = [];
+    this._parser = new xml2js.Parser();
+  }
+
+  _initXml(xml) {
+    let root = xml.node;
+
+    if (Array.isArray(root.node)) {
+      for (let n of root.node) {
+        if (!n.hasOwnProperty('$')) {
+          continue;
+        }
+        let name = n['$'].name;
+        let path = `${this.path}/${name}`;
+        if (isObjectPathValid(path)) {
+          this.nodes.push(path);
+        }
+      }
+    }
+
+    if (Array.isArray(root.interface)) {
+      for (let i of root.interface) {
+        let iface = ProxyInterface._fromXml(this, i);
+        if (iface !== null) {
+          this.interfaces.push(iface);
+          this.bus.addMatch(`type='signal',interface='${iface.$name}',path='${this.path}'`);
+          for (let signal of iface.$signals) {
+            let event = JSON.stringify({
+              path: this.path,
+              interface: iface.$name,
+              member: signal.name
+            });
+            this.bus.signals.on(event, (body, signature) => {
+              if (signature !== signal.signature) {
+                console.error(`warning: got signature ${signature} for signal ${iface.$name}.${signal.name} (expected ${signal.signature})`);
+                return;
+              }
+              // TODO refactor this into a method
+              let result = [];
+              let signatureTree = parseSignature(signature);
+              for (let i = 0; i < signatureTree.length; ++i) {
+                let tree = signatureTree[i];
+                result.push(variant.parse([[tree], [body[i]]]));
+              }
+              iface.emit.apply(iface, [signal.name].concat(result));
+            });
+          }
+        }
+      }
+    }
+  }
+
+  async _init() {
+    return new Promise((resolve, reject) => {
+      this.bus.invoke(
+        {
+          destination: this.name,
+          path: this.path,
+          interface: 'org.freedesktop.DBus.Introspectable',
+          member: 'Introspect',
+          signature: '',
+          body: []
+        },
+        (err, xml) => {
+          if (err) {
+            reject(err);
+            return;
+          }
+
+          this._parser.parseString(xml, (err, data) => {
+            if (err) {
+              reject(err);
+              return;
+            }
+            this._initXml(data);
+            resolve(this);
+          });
+        }
+      );
+    });
+  }
+
+  getInterface(name) {
+    return this.interfaces.find((i) => i.$name === name);
+  }
+
+  async callMethod(iface, member, inSignature, outSignature, ...args) {
+    args = args || [];
+
+    // TODO refactor this into a method
+    let inSignatureTree = parseSignature(inSignature);
+    let body = [];
+    for (let i = 0; i < args.length; ++i) {
+      if (inSignatureTree[i].type === 'v') {
+        if (args[i].constructor !== Variant) {
+          throw new Error(`method call ${iface}.${member} expected a Variant() argument for arg ${i+1}`);
+        }
+        body.push(variant.jsToMarshalFmt(args[i].signature, args[i].value));
+      } else {
+        body.push(variant.jsToMarshalFmt(inSignatureTree[i], args[i])[1]);
+      }
+    }
+
+    let msg = {
+      member: member,
+      signature: inSignature,
+      destination: this.name,
+      path: this.path,
+      interface: iface,
+      body: body
+    };
+
+    return new Promise(resolve => {
+      this.bus.invoke(msg, (err, ...busResult) => {
+        if (err) {
+          throw new Error(err);
+        }
+        // TODO refactor this into a method
+        let result = [];
+        let outSignatureTree = parseSignature(outSignature);
+        if (outSignatureTree.length === 0) {
+          resolve(null);
+          return;
+        }
+        for (let i = 0; i < outSignatureTree.length; ++i) {
+          let tree = outSignatureTree[i];
+          result.push(variant.parse([[tree], [busResult[i]]]));
+        }
+        if (outSignatureTree.length === 1) {
+          resolve(result[0]);
+        } else {
+          resolve(result);
+        }
+      });
+    });
+  }
+}
+
+module.exports = ProxyObject;

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "abstract-socket": "^2.0.0"
   },
   "devDependencies": {
+    "commander": "^2.19.0",
     "eslint": "^5.0.0",
     "eslint-config-prettier": "^3.0.0",
     "eslint-plugin-markdown": "^1.0.0-beta.6",


### PR DESCRIPTION
Add `bus.getProxyObject()` to get a proxy object for an object on the
bus. The proxy object contains introspection data for the object
including the nodes and interfaces.

Interfaces can be gotten with `object.getInterface()` with the name of
the interface. The interface includes methods to call on the bus based
on the introspection data.

The interface is an event emitter which emits signals for the object on
the bus.

See the new mpris.js example and the README for more details.