### PR TITLE
Enable TCP connections and export createClient method

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,12 @@ let createClient = function(params) {
 };
 
 /**
+ * Create a new {@link MessageBus} client on a manually defined bus to connect to
+ * interfaces or request service names. Connects to the socket specified by the
+ * properties assigned.
+ */
+module.exports.createClient = createClient;
+/**
  * Create a new {@link MessageBus} client on the DBus system bus to connect to
  * interfaces or request service names. Connects to the socket specified by the
  * `DBUS_SYSTEM_BUS_ADDRESS` environment variable or

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -32,7 +32,9 @@ function createStream(opts) {
     try {
       switch (family.toLowerCase()) {
         case 'tcp':
-          throw new Error('tcp dbus connections are not supported');
+          host = params.host || 'localhost';
+          port = params.port;
+          return net.createConnection(port, host);
         case 'unix':
           if (params.socket) {
             return net.createConnection(params.socket);


### PR DESCRIPTION
I'd like to connect to a bus on a remote machine (for easier development from my mac). To do this, I've disabled authentication on my linux VM's system bus and started up socat to forward my dbus to the correct socket. 
To be able to connect to the TCP endpoint, I exported the createClient method in de index.js module and added support for TCP connections. I've tested this to be working in my set-up:
```js
let remoteSystemBus = dbus.createClient({
  busAddress: "tcp:host=10.211.55.36,port=7272",
  authMethods: ["ANONYMOUS"]
});
let obj = await remoteSystemBus.getProxyObject(
  "org.freedesktop.NetworkManager",
  "/org/freedesktop/NetworkManager"
);
let props = obj.getInterface("org.freedesktop.DBus.Properties");
let result = await props.Get("org.freedesktop.NetworkManager", "Version");
console.log(result);
// Variant {signature: "s", value: "1.6.2"}
```