### PR TITLE
Changed client creation interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This is a brief example of using a proxy object with the [MPRIS](https://specifi
 
 ```js
 let dbus = require('dbus-next');
-let bus = dbus.sessionBus();
+let bus = dbus.connect({ bus: "session" });
 let Variant = dbus.Variant;
 
 // getting an object introspects it on the bus and creates the interfaces
@@ -84,7 +84,7 @@ let {
   ACCESS_READ, ACCESS_WRITE, ACCESS_READWRITE
 } = dbus.interface;
 
-let bus = dbus.sessionBus();
+let bus = dbus.connect({ bus: "session" });
 
 class ExampleInterface extends Interface {
   @property({signature: 's', access: ACCESS_READWRITE})
@@ -177,7 +177,7 @@ The low-level interface can be used to interact with messages directly. Create n
 let dbus = require('dbus-next');
 let Message = dbus.Message;
 
-let bus = dbus.sessionBus();
+let bus = dbus.connect({ bus: "session" });
 
 // send a method call to list the names on the bus
 let methodCall = new Message({

--- a/bin/dbus-next-send.js
+++ b/bin/dbus-next-send.js
@@ -115,7 +115,9 @@ if (!Array.isArray(body)) {
   exitError('body must be an array of arguments');
 }
 
-let bus = (program.system ? dbus.systemBus() : dbus.sessionBus());
+let bus = dbus.connect({
+  bus: program.system ? "system" : "session"
+});
 
 let message = new Message({
   type: type,

--- a/examples/mpris.js
+++ b/examples/mpris.js
@@ -8,7 +8,7 @@ const PROPERTIES_IFACE = 'org.freedesktop.DBus.Properties';
 
 async function listAll() {
   let result = [];
-  let bus = dbus.sessionBus();
+  let bus = dbus.connect({ bus: "session" });
   let obj = await bus.getProxyObject('org.freedesktop.DBus', '/org/freedesktop/DBus');
   let iface = obj.getInterface('org.freedesktop.DBus');
   let names = await iface.ListNames();
@@ -107,7 +107,7 @@ async function main() {
     playerName = `org.mpris.MediaPlayer2.${program.player}`;
   }
 
-  let bus = dbus.sessionBus();
+  let bus = dbus.connect({ bus: "session" });
   let obj = await bus.getProxyObject(playerName, MPRIS_PATH);
   let player = obj.getInterface(MPRIS_IFACE);
   let props = obj.getInterface(PROPERTIES_IFACE);

--- a/examples/service/index.js
+++ b/examples/service/index.js
@@ -6,7 +6,7 @@ let {
   ACCESS_READ, ACCESS_WRITE, ACCESS_READWRITE
 } = dbus.interface;
 
-let bus = dbus.sessionBus();
+let bus = dbus.connect({ bus: "session" });
 
 class ExampleInterface extends Interface {
   @property({signature: 's', access: ACCESS_READWRITE})

--- a/index.js
+++ b/index.js
@@ -6,40 +6,42 @@ const {Message} = require('./lib/message-type.js');
 const iface = require('./lib/service/interface');
 const createConnection = require('./lib/connection.js');
 
-let createClient = function(params) {
-  let connection = createConnection(params || {});
-  return new MessageBus(connection);
-};
-
 /**
- * Create a new {@link MessageBus} client on the DBus system bus to connect to
- * interfaces or request service names. Connects to the socket specified by the
- * `DBUS_SYSTEM_BUS_ADDRESS` environment variable or
- * `unix:path=/var/run/dbus/system_bus_socket`.
- *
- */
-module.exports.systemBus = function() {
-  return createClient({
-    busAddress:
-      process.env.DBUS_SYSTEM_BUS_ADDRESS ||
-      'unix:path=/var/run/dbus/system_bus_socket'
-  });
-};
-
-/**
- * Create a new {@link MessageBus} client on the DBus session bus to connect to
+ * Create a new {@link MessageBus} client on the DBus bus specified to connect to
  * interfaces or request service names.
  *
  * @param {object} [options] - Options for `MessageBus` creation.
- * @param {object} [options.busAddress] - The socket path for the session bus.
- * Defaults to finding the bus address in the manner specified in the DBus
- * specification. The bus address will first be read from the
+ * @param {object} [options.bus] - The bus specification. Can be either "system", "session"
+ * or a bus address in URI form. If "system" or "session" is given, it will try to find the bus
+ * address in the manner specified in the DBus specification.
+ * This means that for the "system" option, it connects to the socket specified by the
+ * `DBUS_SYSTEM_BUS_ADDRESS` environment variable or
+ * `unix:path=/var/run/dbus/system_bus_socket`.
+ * For the "session" option, it will try to find the bus address in the manner specified in the
+ * DBus specification. The bus address will first be read from the
  * `DBUS_SESSION_BUS_ADDRESS` environment variable and when that is not
  * available, found from the `$HOME/.dbus` directory.
+ * If the bus is in URI form, it will try to connect to the specified socket.
+ * Supported formats are, as specified in the DBus specification:
+ * `tcp:host=<HOST>,port=<PORT>`
+ * `unix:path=<PATH>`
+ * `unixexec:path=<PATH>,arg1=<ARG>,arg2=<ARG>,argN=<ARG>`
+ * @param {object} [options.authMethods] - array of authentication methods, which are attempted
+ * in the order provided (default:['EXTERNAL', 'DBUS_COOKIE_SHA1', 'ANONYMOUS'])
  */
-module.exports.sessionBus = function(opts) {
-  return createClient(opts);
-};
+module.exports.connect = function(opts) {
+  opts = opts || {};
+  if (opts.bus === "system") {
+    opts.busAddress = process.env.DBUS_SYSTEM_BUS_ADDRESS ||
+      'unix:path=/var/run/dbus/system_bus_socket'
+  } else if (opts.bus === "session") {
+    opts.busAddress = undefined
+  } else {
+    opts.busAddress = opts.bus
+  }
+  let connection = createConnection(opts);
+  return new MessageBus(connection);
+}
 
 /**
  * A flag for {@link MessageBus#requestName} to indicate this name allows other

--- a/lib/bus.js
+++ b/lib/bus.js
@@ -21,8 +21,7 @@ let { Interface } = require('./service/interface');
  * of requesting a service [`Name`]{@link module:interface~Name} to export an
  * [`Interface`]{@link module:interface~Interface}, or getting a proxy object
  * to interact with an existing name on the bus as a client. A `MessageBus` is
- * created with `dbus.sessionBus()` or `dbus.systemBus()` methods of the
- * dbus-next module.
+ * created with the `dbus.connect()` method of the dbus-next module.
  *
  * The `MessageBus` is an `EventEmitter` which emits the following events:
  * * `error` - The underlying connection to the bus has errored.  After
@@ -34,7 +33,7 @@ let { Interface } = require('./service/interface');
  *
  * @example
  * const dbus = require('dbus-next');
- * const bus = dbus.sessionBus();
+ * const bus = dbus.connect({ bus: "session" });
  * // get a proxy object
  * let obj = await bus.getProxyObject('org.freedesktop.DBus', '/org/freedesktop/DBus');
  * // request a service name
@@ -43,8 +42,7 @@ let { Interface } = require('./service/interface');
 class MessageBus extends EventEmitter {
   /**
    * Create a new `MessageBus`. This constructor is not to be called directly.
-   * Use `dbus.sessionBus()` or `dbus.systemBus()` to set up the connection to
-    * the bus.
+   * Use `dbus.connect()` to set up the connection to the bus.
    */
   constructor(conn) {
     super();
@@ -246,8 +244,8 @@ class MessageBus extends EventEmitter {
    *
    * @param {methodHandler} - A function to handle a {@link Message} of type
    * {@link MESSAGE_TYPE_METHOD_RETURN}. Takes the `Message` as the first
-    * argument. Return `true` if the method is handled and no further handlers
-    * will run.
+   * argument. Return `true` if the method is handled and no further handlers
+   * will run.
    */
   addMethodHandler(fn) {
     this._methodHandlers.push(fn);

--- a/lib/client/proxy-interface.js
+++ b/lib/client/proxy-interface.js
@@ -22,7 +22,7 @@ const {
  * // this demonstrates the use of the standard
  * // `org.freedesktop.DBus.Properties` interface for an interface that exports
  * // some properties.
- * let bus = dbus.sessionBus();
+ * let bus = dbus.connect({ bus: "session" });
  * let obj = await bus.getProxyObject('org.test.bus_name', '/org/test/path');
  * let properties = obj.getInterface('org.freedesktop.DBus.Properties');
  * // the `Get` method provided by this interface takes two strings and returns

--- a/lib/client/proxy-object.js
+++ b/lib/client/proxy-object.js
@@ -21,7 +21,7 @@ const {
  * be used to call methods and receive signals for that interface.
  *
  * @example
- * let bus = dbus.sessionBus();
+ * let bus = dbus.connect({ bus: "session" });
  * let obj = await bus.getProxyObject('org.freedesktop.DBus', '/org/freedesktop/DBus');
  * let peer = obj.getInterface('org.freedesktop.DBus.Peer')
  * await peer.Ping();

--- a/lib/service/interface.js
+++ b/lib/service/interface.js
@@ -237,7 +237,7 @@ function signal(options) {
  *    }
  *    // define properties, methods, and signals with decorated functions
  * }
- * let bus = dbus.sessionBus();
+ * let bus = dbus.connect({ bus: "session" });
  * let name = await bus.requestName('org.test.bus_name');
  * let iface = new MyInterface();
  * name.export('/org/test/path', iface);

--- a/test/integration/client-standard-dbus.test.js
+++ b/test/integration/client-standard-dbus.test.js
@@ -2,7 +2,7 @@
 // correctly
 
 let dbus = require('../../');
-let bus = dbus.sessionBus();
+let bus = dbus.connect({ bus: "session" });
 bus.on('error', (err) => {
   console.log(`got unexpected connection error:\n${err.stack}`);
 });

--- a/test/integration/export.test.js
+++ b/test/integration/export.test.js
@@ -12,11 +12,11 @@ const TEST_NAME = 'org.test.export';
 const TEST_PATH = '/org/test/path';
 const TEST_IFACE = 'org.test.iface';
 
-let bus = dbus.sessionBus();
+let bus = dbus.connect({ bus: "session" });
 bus.on('error', (err) => {
   console.log(`got unexpected connection error:\n${err.stack}`);
 });
-let bus2 = dbus.sessionBus();
+let bus2 = dbus.connect({ bus: "session" });
 bus2.on('error', (err) => {
   console.log(`got unexpected connection error:\n${err.stack}`);
 });

--- a/test/integration/long-compat.test.js
+++ b/test/integration/long-compat.test.js
@@ -25,7 +25,7 @@ const TEST_PATH = '/org/test/path';
 const TEST_IFACE = 'org.test.iface';
 const TEST_ERROR_PATH = 'org.test.name.error';
 
-let bus = dbus.sessionBus();
+let bus = dbus.connect({ bus: "session" });
 bus.on('error', (err) => {
   console.log(`got unexpected connection error:\n${err.stack}`);
 });

--- a/test/integration/long.test.js
+++ b/test/integration/long.test.js
@@ -27,7 +27,7 @@ const TEST_NAME = 'org.test.long';
 const TEST_PATH = '/org/test/path';
 const TEST_IFACE = 'org.test.iface';
 
-let bus = dbus.sessionBus();
+let bus = dbus.connect({ bus: "session" });
 bus.on('error', (err) => {
   console.log(`got unexpected connection error:\n${err.stack}`);
 });

--- a/test/integration/low-level.test.js
+++ b/test/integration/low-level.test.js
@@ -7,8 +7,8 @@ let {
   MESSAGE_TYPE_ERROR
 } = dbus;
 
-let bus1 = dbus.sessionBus();
-let bus2 = dbus.sessionBus();
+let bus1 = dbus.connect({ bus: "session" });
+let bus2 = dbus.connect({ bus: "session" });
 
 bus1.on('error', (err) => {
   console.log(`bus1 got unexpected connection error:\n${err.stack}`);

--- a/test/integration/methods.test.js
+++ b/test/integration/methods.test.js
@@ -13,7 +13,7 @@ const TEST_NAME = 'org.test.methods';
 const TEST_PATH = '/org/test/path';
 const TEST_IFACE = 'org.test.iface';
 
-let bus = dbus.sessionBus();
+let bus = dbus.connect({ bus: "session" });
 bus.on('error', (err) => {
   console.log(`got unexpected connection error:\n${err.stack}`);
 });

--- a/test/integration/properties.test.js
+++ b/test/integration/properties.test.js
@@ -15,7 +15,7 @@ const TEST_IFACE = 'org.test.iface';
 const USER_ERROR_IFACE = 'org.test.usererror';
 const INVALID_ARGS = 'org.freedesktop.DBus.Error.InvalidArgs'
 
-let bus = dbus.sessionBus();
+let bus = dbus.connect({ bus: "session" });
 bus.on('error', (err) => {
   console.log(`got unexpected connection error:\n${err.stack}`);
 });

--- a/test/integration/service-errors.test.js
+++ b/test/integration/service-errors.test.js
@@ -13,7 +13,7 @@ const TEST_NAME = 'org.test.service_errors';
 const TEST_PATH = '/org/test/path';
 const TEST_IFACE = 'org.test.iface';
 
-let bus = dbus.sessionBus();
+let bus = dbus.connect({ bus: "session" });
 bus.on('error', (err) => {
   console.log(`got unexpected connection error:\n${err.stack}`);
 });

--- a/test/integration/service-options.test.js
+++ b/test/integration/service-options.test.js
@@ -13,7 +13,7 @@ const TEST_NAME = 'org.test.service_options';
 const TEST_PATH = '/org/test/path';
 const TEST_IFACE = 'org.test.iface';
 
-let bus = dbus.sessionBus();
+let bus = dbus.connect({ bus: "session" });
 bus.on('error', (err) => {
   console.log(`got unexpected connection error:\n${err.stack}`);
 });

--- a/test/integration/signals.test.js
+++ b/test/integration/signals.test.js
@@ -14,11 +14,11 @@ const TEST_NAME2 = 'org.test.signals_name2';
 const TEST_PATH = '/org/test/path';
 const TEST_IFACE = 'org.test.iface';
 
-let bus = dbus.sessionBus();
+let bus = dbus.connect({ bus: "session" });
 bus.on('error', (err) => {
   console.log(`got unexpected connection error:\n${err.stack}`);
 });
-let bus2 = dbus.sessionBus();
+let bus2 = dbus.connect({ bus: "session" });
 bus2.on('error', (err) => {
   console.log(`got unexpected connection error:\n${err.stack}`);
 });


### PR DESCRIPTION
Replaced `dbus.systemBus()` and `dbus.sessionBus()` with `dbus.connect({bus: "system"})` and `dbus.connect({bus: "session"})`, respectively, as discussed in #23 