### PR TITLE
Enable TCP support

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -32,7 +32,9 @@ function createStream(opts) {
     try {
       switch (family.toLowerCase()) {
         case 'tcp':
-          throw new Error('tcp dbus connections are not supported');
+          host = params.host || 'localhost';
+          port = params.port;
+          return net.createConnection(port, host);
         case 'unix':
           if (params.socket) {
             return net.createConnection(params.socket);


### PR DESCRIPTION
Enabled TCP support, based on the way it's implemented in the upstream library. I split this out from #23.